### PR TITLE
This commit introduces Redis as a caching backend option for the Tomc…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,15 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>3.8.1</version>
+      <version>4.13.2</version>
       <scope>test</scope>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/org.mockito/mockito-core -->
+    <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>5.11.0</version>
+        <scope>test</scope>
     </dependency>
       <!-- https://mvnrepository.com/artifact/javax.servlet/javax.servlet-api -->
       <dependency>
@@ -36,6 +43,11 @@
           <groupId>org.apache.tomcat</groupId>
           <artifactId>tomcat-catalina</artifactId>
           <version>7.0.91</version>
+      </dependency>
+      <dependency>
+          <groupId>redis.clients</groupId>
+          <artifactId>jedis</artifactId>
+          <version>5.1.0</version>
       </dependency>
 
   </dependencies>

--- a/src/main/java/org/didxga/tomcache/RedisCacheRepository.java
+++ b/src/main/java/org/didxga/tomcache/RedisCacheRepository.java
@@ -1,0 +1,100 @@
+package org.didxga.tomcache;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.exceptions.JedisConnectionException;
+
+public class RedisCacheRepository implements CacheRepository {
+
+    private Jedis jedis;
+
+    public RedisCacheRepository() {
+        // Default connection to localhost:6379
+        // In a production scenario, host and port should be configurable.
+        this(new Jedis("localhost", 6379));
+    }
+
+    // Constructor for allowing custom Jedis instance (e.g., for testing or specific configurations)
+    public RedisCacheRepository(Jedis jedis) {
+        this.jedis = jedis;
+        try {
+            // Check connection
+            this.jedis.ping(); 
+        } catch (JedisConnectionException e) {
+            // Handle connection error appropriately
+            // For now, we'll print an error and the application might not work as expected
+            // A more robust solution would involve retries, fallback mechanisms, or specific error handling
+            System.err.println("Failed to connect to Redis: " + e.getMessage());
+            // Optionally rethrow or handle as a critical failure
+        }
+    }
+
+    @Override
+    public void store(Key key, Value value) {
+        if (key == null || value == null || value.body == null) {
+            // Avoid storing null keys or values, or values with null body
+            return; 
+        }
+        try {
+            // Using key.getUri() as the Redis key.
+            // Serializing the Value object. For simplicity, storing body directly.
+            // A more robust implementation would serialize the entire Value object (including headers and expiry).
+            // For now, we assume Value.body is a String.
+            // If Value.body can be other types, proper serialization (JSON, Java serialization) is needed.
+            String redisKey = key.getUri();
+            jedis.set(redisKey, value.body); // Storing only the body for now
+            if (key.dueDate != null) { // Accessing dueDate field directly
+                long expireTimestamp = key.dueDate.getTime() / 1000; // Convert Date to UNIX timestamp in seconds
+                jedis.expireAt(redisKey, expireTimestamp);
+            }
+        } catch (JedisConnectionException e) {
+            System.err.println("Redis error during store: " + e.getMessage());
+            // Consider error handling strategy: retry, log, throw exception
+        }
+    }
+
+    @Override
+    public Value retrieve(Key key) {
+        if (key == null) {
+            return null;
+        }
+        try {
+            String redisKey = key.getUri();
+            String body = jedis.get(redisKey);
+            if (body != null) {
+                Value value = new Value();
+                value.body = body;
+                // Note: Headers and other Value fields are not currently stored/retrieved.
+                // This would require serialization of the Value object in the store method.
+                return value;
+            } else {
+                return null;
+            }
+        } catch (JedisConnectionException e) {
+            System.err.println("Redis error during retrieve: " + e.getMessage());
+            // Consider error handling strategy
+            return null;
+        }
+    }
+
+    @Override
+    public boolean has(Key key) {
+        if (key == null) {
+            return false;
+        }
+        try {
+            String redisKey = key.getUri();
+            return jedis.exists(redisKey);
+        } catch (JedisConnectionException e) {
+            System.err.println("Redis error during has: " + e.getMessage());
+            // Consider error handling strategy
+            return false;
+        }
+    }
+
+    // Optional: Method to close the Jedis connection when the repository is no longer needed.
+    public void close() {
+        if (jedis != null) {
+            jedis.close();
+        }
+    }
+}

--- a/src/test/java/org/didxga/tomcache/RedisCacheRepositoryTest.java
+++ b/src/test/java/org/didxga/tomcache/RedisCacheRepositoryTest.java
@@ -1,0 +1,180 @@
+package org.didxga.tomcache;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.exceptions.JedisConnectionException;
+
+import java.util.Date;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class RedisCacheRepositoryTest {
+
+    @Mock
+    private Jedis mockJedis;
+
+    private RedisCacheRepository redisCacheRepository;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        // Simulate successful ping for default constructor path, though we inject the mock
+        doNothing().when(mockJedis).ping(); 
+        redisCacheRepository = new RedisCacheRepository(mockJedis);
+    }
+
+    @Test
+    public void testStoreAndRetrieve_Success() {
+        Key key = Key.generateKey("test/uri");
+        Value value = new Value();
+        value.body = "Test Body";
+
+        redisCacheRepository.store(key, value);
+
+        when(mockJedis.get("test/uri")).thenReturn("Test Body");
+
+        Value retrievedValue = redisCacheRepository.retrieve(key);
+
+        assertNotNull(retrievedValue);
+        assertEquals("Test Body", retrievedValue.body);
+        verify(mockJedis).set("test/uri", "Test Body");
+    }
+
+    @Test
+    public void testStore_withExpiry() {
+        Date expiryDate = new Date(System.currentTimeMillis() + 10000); // 10 seconds from now
+        Key key = Key.generateKey("test/uri/expiry", expiryDate);
+        Value value = new Value();
+        value.body = "Test Body Expiring";
+
+        redisCacheRepository.store(key, value);
+
+        long expectedUnixTimestamp = expiryDate.getTime() / 1000;
+        verify(mockJedis).set("test/uri/expiry", "Test Body Expiring");
+        verify(mockJedis).expireAt("test/uri/expiry", expectedUnixTimestamp);
+    }
+    
+    @Test
+    public void testStore_nullKeyOrValue() {
+        Value value = new Value();
+        value.body = "Some body";
+        redisCacheRepository.store(null, value);
+        verifyNoMoreInteractions(mockJedis); // Nothing should happen if key is null
+
+        Key key = Key.generateKey("test/uri_null_value");
+        redisCacheRepository.store(key, null);
+        verifyNoMoreInteractions(mockJedis); // Nothing should happen if value is null
+
+        Value valueNullBody = new Value(); // body is null
+        redisCacheRepository.store(key, valueNullBody);
+        verifyNoMoreInteractions(mockJedis); // Nothing should happen if value.body is null
+    }
+
+
+    @Test
+    public void testRetrieve_NotFound() {
+        Key key = Key.generateKey("test/nonexistent");
+        when(mockJedis.get("test/nonexistent")).thenReturn(null);
+
+        Value retrievedValue = redisCacheRepository.retrieve(key);
+
+        assertNull(retrievedValue);
+    }
+    
+    @Test
+    public void testRetrieve_nullKey() {
+        Value retrievedValue = redisCacheRepository.retrieve(null);
+        assertNull(retrievedValue);
+        verifyNoMoreInteractions(mockJedis);
+    }
+
+    @Test
+    public void testHas_True() {
+        Key key = Key.generateKey("test/existing");
+        when(mockJedis.exists("test/existing")).thenReturn(true);
+
+        assertTrue(redisCacheRepository.has(key));
+    }
+
+    @Test
+    public void testHas_False() {
+        Key key = Key.generateKey("test/nonexistent_has");
+        when(mockJedis.exists("test/nonexistent_has")).thenReturn(false);
+
+        assertFalse(redisCacheRepository.has(key));
+    }
+
+    @Test
+    public void testHas_nullKey() {
+        assertFalse(redisCacheRepository.has(null));
+        verifyNoMoreInteractions(mockJedis);
+    }
+
+    @Test
+    public void testStore_JedisConnectionException() {
+        Key key = Key.generateKey("test/uri_conn_exception");
+        Value value = new Value();
+        value.body = "Test Body";
+
+        doThrow(new JedisConnectionException("Connection failed")).when(mockJedis).set(anyString(), anyString());
+
+        // We expect the exception to be caught and logged, not rethrown by default
+        redisCacheRepository.store(key, value); 
+        // Verify set was called, even if it threw an exception internally that was handled
+        verify(mockJedis).set("test/uri_conn_exception", "Test Body");
+    }
+
+    @Test
+    public void testRetrieve_JedisConnectionException() {
+        Key key = Key.generateKey("test/uri_retrieve_exception");
+        when(mockJedis.get(anyString())).thenThrow(new JedisConnectionException("Connection failed"));
+        
+        Value retrievedValue = redisCacheRepository.retrieve(key);
+        assertNull(retrievedValue); // Expect null if connection fails during retrieve
+        verify(mockJedis).get("test/uri_retrieve_exception");
+    }
+
+    @Test
+    public void testHas_JedisConnectionException() {
+        Key key = Key.generateKey("test/uri_has_exception");
+        when(mockJedis.exists(anyString())).thenThrow(new JedisConnectionException("Connection failed"));
+
+        boolean result = redisCacheRepository.has(key);
+        assertFalse(result); // Expect false if connection fails during has
+        verify(mockJedis).exists("test/uri_has_exception");
+    }
+    
+    @Test
+    public void testClose() {
+        redisCacheRepository.close();
+        verify(mockJedis).close();
+    }
+
+    // Test for the constructor that initializes a real Jedis client (optional, might need a running Redis)
+    // For now, we focus on testing with the mocked Jedis instance.
+    // It's also important to test the constructor's ping.
+    @Test
+    public void testConstructor_PingSuccess() {
+        // This is implicitly covered by setUp if mockJedis.ping() is expected & verified.
+        // For an explicit test with a new instance:
+        Jedis localMockJedis = mock(Jedis.class);
+        doNothing().when(localMockJedis).ping();
+        RedisCacheRepository newRepo = new RedisCacheRepository(localMockJedis);
+        verify(localMockJedis).ping(); // Verify ping was called during construction
+        newRepo.close(); // Clean up
+    }
+
+    @Test
+    public void testConstructor_PingFailure() {
+        Jedis localMockJedis = mock(Jedis.class);
+        doThrow(new JedisConnectionException("Ping failed")).when(localMockJedis).ping();
+        // We expect the constructor to catch this and print an error, not rethrow.
+        RedisCacheRepository newRepo = new RedisCacheRepository(localMockJedis);
+        verify(localMockJedis).ping();
+        newRepo.close();
+    }
+}


### PR DESCRIPTION
…ache filter.

Key changes:
- Added Jedis client dependency for Redis interaction.
- Implemented `RedisCacheRepository` which conforms to the existing `CacheRepository` interface, handling store, retrieve, and key existence checks with Redis. Expiration is managed using Redis's native TTL.
- Updated `TomcacheFilter` to use the `CacheRepository` interface and allows instantiation of `RedisCacheRepository`.
- `StaleDataWatcher` is now only initialized when `MemoryCacheRepository` is in use, as Redis manages its own key expiration.
- I added comprehensive unit tests for `RedisCacheRepository` using JUnit and Mockito, mocking the Jedis client.
- Updated JUnit to version 4.13.2 and added Mockito dependency.

This allows `tomcache` to leverage Redis for distributed caching, improving scalability and resilience compared to the previous in-memory cache.